### PR TITLE
NativeAOT compilation. Upgrade to .NET 9 and improve code safety.

### DIFF
--- a/Avalonia.UpDock.Testing/Avalonia.UpDock.Testing.csproj
+++ b/Avalonia.UpDock.Testing/Avalonia.UpDock.Testing.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
-    One for Windows with net7.0-windows TFM, one for MacOS with net7.0-macos and one with net7.0 TFM for Linux.-->
-    <TargetFramework>net7.0</TargetFramework>
+    One for Windows with net9.0-windows TFM, one for MacOS with net9.0-macos and one with net9.0 TFM for Linux.-->
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Avalonia.UpDock.Testing/MainWindow.axaml.cs
+++ b/Avalonia.UpDock.Testing/MainWindow.axaml.cs
@@ -14,7 +14,7 @@ public partial class MainWindow : Window
 {
     public MainWindow()
     {
-        InitializeComponent(true, true);
+        InitializeComponent();
     }
 
     private void UnclosableTab_Closing(object? sender, System.ComponentModel.CancelEventArgs e)

--- a/Avalonia.UpDock/Avalonia.UpDock.csproj
+++ b/Avalonia.UpDock/Avalonia.UpDock.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>

--- a/Avalonia.UpDock/Controls/DockingHost.cs
+++ b/Avalonia.UpDock/Controls/DockingHost.cs
@@ -31,24 +31,24 @@ public partial class DockingHost : DockSplitPanel
         DockIndicatorFieldStrokeThicknessProperty.GetDefaultValue(typeof(DockingTabControl)));
 
     #region Properties
-    public static StyledProperty<double> DockIndicatorFieldSizeProperty { get; private set; } =
+    public static StyledProperty<double> DockIndicatorFieldSizeProperty { get; } =
         AvaloniaProperty.Register<DockingTabControl, double>(nameof(DockIndicatorFieldSize), 40);
 
-    public static StyledProperty<double> DockIndicatorFieldSpacingProperty { get; private set; } =
+    public static StyledProperty<double> DockIndicatorFieldSpacingProperty { get; } =
         AvaloniaProperty.Register<DockingTabControl, double>(nameof(DockIndicatorFieldSpacing), 10);
 
-    public static StyledProperty<float> DockIndicatorFieldCornerRadiusProperty { get; private set; } =
+    public static StyledProperty<float> DockIndicatorFieldCornerRadiusProperty { get; } =
         AvaloniaProperty.Register<DockingTabControl, float>(nameof(DockIndicatorFieldCornerRadius), 5);
 
-    public static StyledProperty<IBrush> DockIndicatorFieldFillProperty { get; private set; } =
+    public static StyledProperty<IBrush> DockIndicatorFieldFillProperty { get; } =
         AvaloniaProperty.Register<DockingTabControl, IBrush>(nameof(DockIndicatorFieldFill), new SolidColorBrush(Colors.CornflowerBlue, 0.5));
-    public static StyledProperty<IBrush> DockIndicatorFieldHoveredFillProperty { get; private set; } =
+    public static StyledProperty<IBrush> DockIndicatorFieldHoveredFillProperty { get; } =
         AvaloniaProperty.Register<DockingTabControl, IBrush>(nameof(DockIndicatorFieldHoveredFill), new SolidColorBrush(Colors.CornflowerBlue));
 
-    public static StyledProperty<IBrush> DockIndicatorFieldStrokeProperty { get; private set; } =
+    public static StyledProperty<IBrush> DockIndicatorFieldStrokeProperty { get; } =
         AvaloniaProperty.Register<DockingTabControl, IBrush>(nameof(DockIndicatorFieldStroke), Brushes.CornflowerBlue);
 
-    public static StyledProperty<double> DockIndicatorFieldStrokeThicknessProperty { get; private set; } =
+    public static StyledProperty<double> DockIndicatorFieldStrokeThicknessProperty { get; } =
         AvaloniaProperty.Register<DockingTabControl, double>(nameof(DockIndicatorFieldStrokeThickness), 1);
 
     public double DockIndicatorFieldSize
@@ -157,8 +157,10 @@ public partial class DockingHost : DockSplitPanel
 
     private void UnregisterSplitPanel(SplitPanel splitPanel)
     {
-        Debug.Assert(_registeredSplitPanels.Remove(splitPanel, out var handler));
-        splitPanel.Children.CollectionChanged -= handler;
+        if (_registeredSplitPanels.Remove(splitPanel, out var handler))
+            splitPanel.Children.CollectionChanged -= handler;
+        else
+            throw new Exception("SplitPanel not registered");
 
         foreach (var child in splitPanel.Children)
         {
@@ -183,8 +185,10 @@ public partial class DockingHost : DockSplitPanel
 
     private void UnregisterTabControl(TabControl tabControl)
     {
-        Debug.Assert(_registeredTabControls.Remove(tabControl, out var handler));
-        tabControl.Items.CollectionChanged -= handler;
+        if (_registeredTabControls.Remove(tabControl, out var handler))
+            tabControl.Items.CollectionChanged -= handler;
+        else
+            throw new Exception("TabControl not registered");
 
         if (tabControl is DockingTabControl dockingTabControl)
             dockingTabControl.UnregisterDraggedOutTabHanlder();


### PR DESCRIPTION
* Updated target framework to .NET 9 in project files.
* Removed redundant `private set` modifiers in styled properties.
* Replaced `Debug.Assert` checks with exceptions to ensure errors are properly handled at runtime.
* Simplified `InitializeComponent` call in `MainWindow`.